### PR TITLE
gitignore to include subdir READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 .DS_Store
 .quarto
 
-# Exclude the following directories 
-/data/
+# Exclude the following directories
+/data/ 
+!/data/README.md
 /output/
+!/output/README.md
 
 # Exclude data file types
 *.doc


### PR DESCRIPTION
Modified to exclude the folders themselves from the .gitignore so empty folders appear in the repo.
Reasons described in Issue 3

Question if the READMEs within data and output also need to be preserved as people will see them when they clone the template, it's just that the READMEs won't remain when the template is committed to a new project.